### PR TITLE
Derive count of api servers from etcd config

### DIFF
--- a/pkg/kubeadm/kubeadm.go
+++ b/pkg/kubeadm/kubeadm.go
@@ -38,6 +38,7 @@ type Config struct {
 	KubeletId			string
 	CloudProvider		string
 	KubeVersion			string
+	MasterCount			uint
 }
 
 type SharedAssets struct {

--- a/pkg/kubeadm/manifests.go
+++ b/pkg/kubeadm/manifests.go
@@ -6,15 +6,10 @@ import (
 )
 
 func WriteManifests(kubeadmCfg Config) (err error) {
+	// Get config into kubeadm format
 	var cfg *kubeadmapi.MasterConfiguration
 	if cfg, err = GetKubeadmCfg(kubeadmCfg); err != nil {
 		return err
 	}
-	if cfg == nil {
-		return nil
-	}
-	if master.WriteStaticPodManifests(cfg) ; err != nil {
-		return err
-	}
-	return nil
+	return master.WriteStaticPodManifests(cfg, kubeadmCfg.MasterCount)
 }

--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/master/manifests.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/master/manifests.go
@@ -61,7 +61,7 @@ Changes required - to be reviewed but hacked in to be compatible with working us
 
 // WriteStaticPodManifests builds manifest objects based on user provided configuration and then dumps it to disk
 // where kubelet will pick and schedule them.
-func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
+func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration, masterCount uint) error {
 	volumes := []api.Volume{k8sVolume(cfg)}
 	volumeMounts := []api.VolumeMount{k8sVolumeMount()}
 
@@ -88,7 +88,7 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 		kubeAPIServer: componentPod(api.Container{
 			Name:          kubeAPIServer,
 			Image:         images.GetCoreImage(images.KubeAPIServerImage, cfg, kubeadmapi.GlobalEnvParams.HyperkubeImage),
-			Command:       getAPIServerCommand(cfg, false),
+			Command:       append(getAPIServerCommand(cfg, false), fmt.Sprintf("--apiserver-count=%d", masterCount)),
 			VolumeMounts:  apiVolumeMounts,
 			LivenessProbe: componentProbe(int(cfg.API.BindPort), "/healthz", api.URISchemeHTTPS),
 			Resources:     componentResources("250m"),


### PR DESCRIPTION
Will use the environment variable / etcd flag to derive the correct number of api servers. API servers will go down unless they know of each other.